### PR TITLE
change gh pages workflow to deploy from main

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,7 +2,7 @@ name: GitHub Pages
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   deploy:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
i changed the default branch name. Let's make sure the deploy works with the new branch name. 