### PR TITLE
Fixes to actions-generated PRs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
           delete-branch: true
           title: "publish: ${{ github.event.issue.title }}"
           body: |
-            This is an automatically generated post from Issue ${{ github.event.issue.number }}
+            This is an automatically generated post from Issue #${{ github.event.issue.number }} originally authored by @${{ github.event.issue.user.login }}.
 
             Merging will publish to: https://yt-project.github.io/blog/posts//${{ github.event.issue.title }}
             Closes #${{ github.event.issue.number }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,5 +35,5 @@ jobs:
 
             Merging will publish to: https://yt-project.github.io/blog/posts//${{ github.event.issue.title }}
             Closes #${{ github.event.issue.number }}
-          reviewers: "${{ github.repository_owner }}"
+          reviewers: munkm
           commit-message: "post: ${{ github.event.issue.title }}"


### PR DESCRIPTION
This PR should:
- make @munkm the default reviewer on all actions generated PRs. 
- tag the original author of the issue in the PR so they're notified. This should help make it so that even contributors who are not collaborators are notified when the PR is generated. 